### PR TITLE
Fixed getDOY function to work beyond 2020

### DIFF
--- a/index.html
+++ b/index.html
@@ -535,21 +535,11 @@
 <script>
   let lastDay = 366;
 
-  Date.prototype.isLeapYear = function() {
-      const year = this.getFullYear();
-      if((year & 3) != 0) return false;
-      return ((year % 100) != 0 || (year % 400) == 0);
-  };
-
+  
   // Get Day of Year
   Date.prototype.getDOY = function() {
-      const dayCount = [0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334];
-      const mn = this.getMonth();
-      const dn = this.getDate();
-
-      let dayOfYear = dayCount[mn] + dn;
-      if(mn > 1 && this.isLeapYear()) dayOfYear++;
-      return dayOfYear;
+    // get time since 31st of December 2019 in days
+    return Math.floor((this - new Date("December 31, 2019")) / 86400000);
   };
 
   function dayOfMarch(dayOfYear = null) {


### PR DESCRIPTION
Fixes #6.

Fixed the getDOY function to account for days beyond December 31, 2020 / March 306th, 2020.

### Before fix

See Issue #6 

Date is displayed as March -59th, 2020.

### After fix

![image](https://user-images.githubusercontent.com/20955511/103427250-641b8680-4bc8-11eb-8044-2c2df4b5ae66.png)

Dates continue from March 307th, 2020 and onward!